### PR TITLE
Rename MetaSearch third-party service label

### DIFF
--- a/MetaSearch.php
+++ b/MetaSearch.php
@@ -359,7 +359,7 @@ class MetaSearch extends AbstractModule implements
         return [
             'third_party_services' => [
                 [
-                    'name' => 'meta.genealogy.net',
+                    'name' => 'Metasuche',
                     'url' => 'https://meta.genealogy.net/',
                     'country' => 'Germany',
                     'description' => I18N::translate('The MetaSearch module receives search requests from meta.genealogy.net and returns matching result data from the enabled public family trees.'),


### PR DESCRIPTION
## Summary
- Rename the advertised third-party service from `meta.genealogy.net` to `Metasuche`
- Keep the service URL and privacy notice details unchanged

## Verification
- `php -l MetaSearch.php`